### PR TITLE
Configure SQLite with immediate transaction mode and add repo tests

### DIFF
--- a/apps/blog/test/blog/repo_test.exs
+++ b/apps/blog/test/blog/repo_test.exs
@@ -1,0 +1,17 @@
+defmodule Blog.RepoTest do
+  use Blog.DataCase, async: true
+
+  describe "Blog.Repo" do
+    test "can connect and execute basic query" do
+      result = Repo.query("SELECT 1 as value")
+      assert {:ok, %{rows: [[1]]}} = result
+    end
+
+    test "uses immediate transaction mode" do
+      Repo.transaction(fn ->
+        result = Repo.query("PRAGMA defer_foreign_keys")
+        assert {:ok, _} = result
+      end)
+    end
+  end
+end

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,7 +5,8 @@ config :blog, Blog.Repo,
   database: Path.expand("../blog_dev.db", __DIR__),
   pool_size: 5,
   stacktrace: true,
-  show_sensitive_data_on_connection_error: true
+  show_sensitive_data_on_connection_error: true,
+  default_transaction_mode: :immediate
 
 # For development, we disable any cache and enable
 # debugging and code reloading.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -31,7 +31,8 @@ if config_env() == :prod do
 
   config :blog, Blog.Repo,
     database: database_path,
-    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "5")
+    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "5"),
+    default_transaction_mode: :immediate
 
   config :blog, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,7 +8,8 @@ import Config
 config :blog, Blog.Repo,
   database: Path.expand("../blog_test.db", __DIR__),
   pool_size: 5,
-  pool: Ecto.Adapters.SQL.Sandbox
+  pool: Ecto.Adapters.SQL.Sandbox,
+  default_transaction_mode: :immediate
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.


### PR DESCRIPTION
Configure SQLite with immediate transaction mode to prevent database lock errors that commonly occur with SQLite's default deferred transaction mode

Closes #2