### PR TITLE
DRAFT: Add real-time viewer tracking with Phoenix.Presence

### DIFF
--- a/apps/blog_web/assets/css/app.css
+++ b/apps/blog_web/assets/css/app.css
@@ -23,6 +23,7 @@
 @import "components/search.css" layer(components);
 @import "components/tag.css" layer(components);
 @import "components/toc.css" layer(components);
+@import "components/viewers.css" layer(components);
 
 /* Utilities (always win over components) */
 @import "phoenix.css" layer(utilities);

--- a/apps/blog_web/assets/css/components/viewers.css
+++ b/apps/blog_web/assets/css/components/viewers.css
@@ -1,0 +1,31 @@
+/* Viewer Counts Component Styles */
+
+@layer components {
+  .viewer-counts {
+    margin-block-end: var(--space-2line);
+  }
+
+  .viewer-stat {
+    color: var(--color-fg-secondary);
+    margin: 0;
+    margin-block-end: var(--space-half-line);
+  }
+
+  .viewer-stat:last-child {
+    margin-block-end: 0;
+  }
+
+  .viewer-bullet {
+    color: var(--color-accent);
+    margin-inline-end: var(--space-half);
+  }
+
+  .viewer-label {
+    margin-inline-end: var(--space-half);
+  }
+
+  .viewer-count {
+    color: var(--color-fg-primary);
+    font-weight: var(--font-weight-bold);
+  }
+}

--- a/apps/blog_web/lib/blog_web/application.ex
+++ b/apps/blog_web/lib/blog_web/application.ex
@@ -9,6 +9,7 @@ defmodule BlogWeb.Application do
   def start(_type, _args) do
     children = [
       BlogWeb.Telemetry,
+      BlogWeb.Presence,
       # Start a worker by calling: BlogWeb.Worker.start_link(arg)
       # {BlogWeb.Worker, arg},
       # Start to serve requests, typically the last entry

--- a/apps/blog_web/lib/blog_web/components/viewers.ex
+++ b/apps/blog_web/lib/blog_web/components/viewers.ex
@@ -1,0 +1,37 @@
+defmodule BlogWeb.Components.Viewers do
+  @moduledoc """
+  Viewer count component for displaying real-time viewer statistics.
+  """
+  use Phoenix.Component
+
+  @doc """
+  Renders viewer count information in the aside.
+
+  ## Examples
+
+      <.counts site_count={@site_viewer_count} page_count={@page_viewer_count} />
+  """
+  attr :site_count, :integer, required: true
+  attr :page_count, :integer, required: true
+  attr :id, :string, default: "viewer-counts"
+
+  def counts(assigns) do
+    ~H"""
+    <aside id={@id} class="viewer-counts" aria-label="Viewer Counts">
+      <h2 class="aside-section-header">Viewers</h2>
+
+      <p class="viewer-stat">
+        <span class="viewer-bullet">•</span>
+        <span class="viewer-label">Site-wide:</span>
+        <span class="viewer-count">{@site_count}</span>
+      </p>
+
+      <p class="viewer-stat">
+        <span class="viewer-bullet">•</span>
+        <span class="viewer-label">This page:</span>
+        <span class="viewer-count">{@page_count}</span>
+      </p>
+    </aside>
+    """
+  end
+end

--- a/apps/blog_web/lib/blog_web/live/home_live.ex
+++ b/apps/blog_web/lib/blog_web/live/home_live.ex
@@ -6,7 +6,8 @@ defmodule BlogWeb.HomeLive do
   alias BlogWeb.Components.Discord
   alias BlogWeb.Components.Post
   alias BlogWeb.Components.TableOfContents
-  alias BlogWeb.Viewers
+  alias BlogWeb.Components.Viewers
+  alias BlogWeb.Viewers, as: ViewersContext
 
   @slug "hello-world"
 
@@ -17,20 +18,20 @@ defmodule BlogWeb.HomeLive do
       Phoenix.PubSub.subscribe(Blog.PubSub, "discord:presence")
 
       # Track viewer on both site-wide and page-specific topics
-      Viewers.track_viewer(self(), Viewers.site_topic(), socket.id)
-      Viewers.track_viewer(self(), Viewers.page_topic(:home), socket.id)
+      ViewersContext.track_viewer(self(), ViewersContext.site_topic(), socket.id)
+      ViewersContext.track_viewer(self(), ViewersContext.page_topic(:home), socket.id)
 
       # Subscribe to viewer count updates
-      Viewers.subscribe(Viewers.site_topic())
-      Viewers.subscribe(Viewers.page_topic(:home))
+      ViewersContext.subscribe(ViewersContext.site_topic())
+      ViewersContext.subscribe(ViewersContext.page_topic(:home))
     end
 
     socket =
       socket
       |> assign(:post, Blog.Posts.get_post(slug: @slug))
       |> assign(:presence, Blog.Discord.get_presence())
-      |> assign(:site_viewer_count, Viewers.get_viewer_count(Viewers.site_topic()))
-      |> assign(:page_viewer_count, Viewers.get_viewer_count(Viewers.page_topic(:home)))
+      |> assign(:site_viewer_count, ViewersContext.get_viewer_count(ViewersContext.site_topic()))
+      |> assign(:page_viewer_count, ViewersContext.get_viewer_count(ViewersContext.page_topic(:home)))
 
     {:ok, socket}
   end
@@ -60,10 +61,10 @@ defmodule BlogWeb.HomeLive do
   @impl Phoenix.LiveView
   def handle_info({:viewer_count_updated, topic, count}, socket) do
     cond do
-      topic == Viewers.site_topic() ->
+      topic == ViewersContext.site_topic() ->
         {:noreply, assign(socket, :site_viewer_count, count)}
 
-      topic == Viewers.page_topic(:home) ->
+      topic == ViewersContext.page_topic(:home) ->
         {:noreply, assign(socket, :page_viewer_count, count)}
 
       true ->
@@ -89,6 +90,7 @@ defmodule BlogWeb.HomeLive do
     <Layouts.app flash={@flash}>
       <:aside>
         <Discord.presence presence={@presence} />
+        <Viewers.counts site_count={@site_viewer_count} page_count={@page_viewer_count} />
 
         <TableOfContents.toc
           headings={

--- a/apps/blog_web/lib/blog_web/presence.ex
+++ b/apps/blog_web/lib/blog_web/presence.ex
@@ -1,0 +1,82 @@
+defmodule BlogWeb.Presence do
+  @moduledoc """
+  Provides real-time presence tracking for viewers across the site.
+
+  This module tracks LiveView processes using Phoenix.Presence and broadcasts
+  presence changes via PubSub. It supports multiple topics for site-wide and
+  page-specific tracking.
+
+  ## Topics
+
+  - `"viewers:site"` - All active users across the entire site
+  - `"viewers:page:home"` - Home page viewers
+  - `"viewers:page:posts"` - Posts list viewers
+  - `"viewers:page:post:<slug>"` - Individual post viewers
+  - `"viewers:page:projects"` - Projects list viewers
+  - `"viewers:page:gallery"` - Gallery viewers
+
+  ## Usage
+
+  In a LiveView:
+
+      alias BlogWeb.Presence
+
+      def mount(_params, _session, socket) do
+        if connected?(socket) do
+          Presence.track(self(), "viewers:site", socket.id, %{})
+        end
+        {:ok, socket}
+      end
+  """
+  use Phoenix.Presence,
+    otp_app: :blog_web,
+    pubsub_server: Blog.PubSub
+
+  @doc """
+  Initializes the presence tracker state.
+
+  This callback is optional but allows us to maintain custom state
+  and react to presence changes.
+  """
+  def init(_opts) do
+    {:ok, %{}}
+  end
+
+  @doc """
+  Handles presence metadata changes and broadcasts them to subscribed processes.
+
+  This callback is invoked whenever there are joins or leaves in any presence topic.
+  We broadcast these changes so that LiveViews can reactively update viewer counts.
+  """
+  def handle_metas(topic, %{joins: joins, leaves: leaves}, presences, state) do
+    # Calculate the current count for this topic
+    count = map_size(presences)
+
+    # Broadcast the updated count to all subscribers of this topic
+    Phoenix.PubSub.local_broadcast(
+      Blog.PubSub,
+      topic,
+      {:viewer_count_updated, topic, count}
+    )
+
+    # Broadcast individual join events
+    for {_key, _presence} <- joins do
+      Phoenix.PubSub.local_broadcast(
+        Blog.PubSub,
+        topic,
+        {:viewer_joined, topic}
+      )
+    end
+
+    # Broadcast individual leave events
+    for {_key, _presence} <- leaves do
+      Phoenix.PubSub.local_broadcast(
+        Blog.PubSub,
+        topic,
+        {:viewer_left, topic}
+      )
+    end
+
+    {:ok, state}
+  end
+end

--- a/apps/blog_web/lib/blog_web/viewers.ex
+++ b/apps/blog_web/lib/blog_web/viewers.ex
@@ -1,0 +1,173 @@
+defmodule BlogWeb.Viewers do
+  @moduledoc """
+  Context module for tracking and querying viewer presence across the site.
+
+  This module provides a clean API for LiveViews to interact with
+  Phoenix.Presence without coupling to the implementation details.
+
+  ## Topics
+
+  - `"viewers:site"` - All active users across the entire site
+  - `"viewers:page:home"` - Home page viewers
+  - `"viewers:page:posts"` - Posts list viewers
+  - `"viewers:page:post:<slug>"` - Individual post viewers
+  - `"viewers:page:projects"` - Projects list viewers
+  - `"viewers:page:gallery"` - Gallery viewers
+  """
+
+  @site_topic "viewers:site"
+
+  @doc """
+  Tracks a viewer on a specific topic.
+
+  ## Parameters
+
+  - `pid` - The process to track (usually `self()` from a LiveView)
+  - `topic` - The presence topic to track on
+  - `key` - Unique identifier for this viewer (usually `socket.id`)
+  - `meta` - Optional metadata map (default: `%{}`)
+
+  ## Examples
+
+      # Track on site-wide topic
+      Viewers.track_viewer(self(), "viewers:site", socket.id)
+
+      # Track on a specific page
+      Viewers.track_viewer(self(), "viewers:page:home", socket.id)
+
+      # Track with metadata
+      Viewers.track_viewer(self(), "viewers:site", socket.id, %{joined_at: System.system_time()})
+  """
+  @spec track_viewer(pid(), String.t(), String.t(), map()) :: {:ok, binary()} | {:error, term()}
+  def track_viewer(pid, topic, key, meta \\ %{}) do
+    BlogWeb.Presence.track(pid, topic, key, meta)
+  end
+
+  @doc """
+  Untracks a viewer from a specific topic.
+
+  ## Parameters
+
+  - `pid` - The process to untrack
+  - `topic` - The presence topic to untrack from
+  - `key` - The unique identifier for this viewer
+
+  ## Examples
+
+      Viewers.untrack_viewer(self(), "viewers:page:posts", socket.id)
+  """
+  @spec untrack_viewer(pid(), String.t(), String.t()) :: :ok
+  def untrack_viewer(pid, topic, key) do
+    BlogWeb.Presence.untrack(pid, topic, key)
+  end
+
+  @doc """
+  Gets the current viewer count for a specific topic.
+
+  ## Examples
+
+      Viewers.get_viewer_count("viewers:site")
+      #=> 5
+
+      Viewers.get_viewer_count("viewers:page:home")
+      #=> 2
+  """
+  @spec get_viewer_count(String.t()) :: non_neg_integer()
+  def get_viewer_count(topic) do
+    topic
+    |> BlogWeb.Presence.list()
+    |> map_size()
+  end
+
+  @doc """
+  Gets viewer counts for all common topics.
+
+  Returns a map with topic names as keys and counts as values.
+
+  ## Examples
+
+      Viewers.get_all_counts()
+      #=> %{
+      #=>   site: 10,
+      #=>   home: 3,
+      #=>   posts: 2,
+      #=>   projects: 1,
+      #=>   gallery: 0
+      #=> }
+  """
+  @spec get_all_counts() :: %{atom() => non_neg_integer()}
+  def get_all_counts do
+    %{
+      site: get_viewer_count(@site_topic),
+      home: get_viewer_count("viewers:page:home"),
+      posts: get_viewer_count("viewers:page:posts"),
+      projects: get_viewer_count("viewers:page:projects"),
+      gallery: get_viewer_count("viewers:page:gallery")
+    }
+  end
+
+  @doc """
+  Subscribes the current process to presence updates for a topic.
+
+  This allows a process to receive `:viewer_count_updated`, `:viewer_joined`,
+  and `:viewer_left` messages.
+
+  ## Examples
+
+      Viewers.subscribe("viewers:site")
+      #=> :ok
+
+      # Later, in handle_info:
+      def handle_info({:viewer_count_updated, topic, count}, socket) do
+        {:noreply, assign(socket, :viewer_count, count)}
+      end
+  """
+  @spec subscribe(String.t()) :: :ok | {:error, term()}
+  def subscribe(topic) do
+    Phoenix.PubSub.subscribe(Blog.PubSub, topic)
+  end
+
+  @doc """
+  Returns the site-wide topic name.
+
+  ## Examples
+
+      Viewers.site_topic()
+      #=> "viewers:site"
+  """
+  @spec site_topic() :: String.t()
+  def site_topic, do: @site_topic
+
+  @doc """
+  Returns the topic name for a specific page.
+
+  ## Parameters
+
+  - `page` - Page identifier (`:home`, `:posts`, `:projects`, `:gallery`)
+
+  ## Examples
+
+      Viewers.page_topic(:home)
+      #=> "viewers:page:home"
+
+      Viewers.page_topic(:posts)
+      #=> "viewers:page:posts"
+  """
+  @type page :: :home | :posts | :projects | :gallery
+  @spec page_topic(page()) :: String.t()
+  def page_topic(:home), do: "viewers:page:home"
+  def page_topic(:posts), do: "viewers:page:posts"
+  def page_topic(:projects), do: "viewers:page:projects"
+  def page_topic(:gallery), do: "viewers:page:gallery"
+
+  @doc """
+  Returns the topic name for a specific post by slug.
+
+  ## Examples
+
+      Viewers.post_topic("hello-world")
+      #=> "viewers:page:post:hello-world"
+  """
+  @spec post_topic(String.t()) :: String.t()
+  def post_topic(slug), do: "viewers:page:post:#{slug}"
+end

--- a/apps/blog_web/test/blog_web/components/viewers_test.exs
+++ b/apps/blog_web/test/blog_web/components/viewers_test.exs
@@ -1,0 +1,79 @@
+defmodule BlogWeb.Components.ViewersTest do
+  use BlogWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias BlogWeb.Components.Viewers
+
+  describe "counts/1" do
+    test "renders viewer counts with default id" do
+      assigns = %{site_count: 10, page_count: 3}
+
+      html = render_component(&Viewers.counts/1, assigns)
+
+      assert html =~ "viewer-counts"
+      assert html =~ "Viewers"
+      assert html =~ "Site-wide:"
+      assert html =~ "10"
+      assert html =~ "This page:"
+      assert html =~ "3"
+    end
+
+    test "renders viewer counts with custom id" do
+      assigns = %{site_count: 5, page_count: 2, id: "custom-viewers"}
+
+      html = render_component(&Viewers.counts/1, assigns)
+
+      assert html =~ ~s(id="custom-viewers")
+      assert html =~ "5"
+      assert html =~ "2"
+    end
+
+    test "renders zero counts correctly" do
+      assigns = %{site_count: 0, page_count: 0}
+
+      html = render_component(&Viewers.counts/1, assigns)
+
+      assert html =~ "Site-wide:"
+      assert html =~ "0"
+      assert html =~ "This page:"
+    end
+
+    test "renders large viewer counts" do
+      assigns = %{site_count: 1_234_567, page_count: 999_999}
+
+      html = render_component(&Viewers.counts/1, assigns)
+
+      # Elixir will render integers with underscore separators as plain numbers
+      assert html =~ "1234567"
+      assert html =~ "999999"
+    end
+
+    test "includes proper ARIA labels" do
+      assigns = %{site_count: 1, page_count: 1}
+
+      html = render_component(&Viewers.counts/1, assigns)
+
+      assert html =~ ~s(aria-label="Viewer Counts")
+    end
+
+    test "includes viewer bullet points" do
+      assigns = %{site_count: 5, page_count: 3}
+
+      html = render_component(&Viewers.counts/1, assigns)
+
+      assert html =~ "viewer-bullet"
+    end
+
+    test "includes proper CSS classes for styling" do
+      assigns = %{site_count: 10, page_count: 5}
+
+      html = render_component(&Viewers.counts/1, assigns)
+
+      assert html =~ "viewer-counts"
+      assert html =~ "viewer-stat"
+      assert html =~ "viewer-label"
+      assert html =~ "viewer-count"
+    end
+  end
+end

--- a/apps/blog_web/test/blog_web/presence_test.exs
+++ b/apps/blog_web/test/blog_web/presence_test.exs
@@ -1,0 +1,98 @@
+defmodule BlogWeb.PresenceTest do
+  use ExUnit.Case, async: true
+
+  alias BlogWeb.Presence
+
+  describe "init/1" do
+    test "returns empty state map" do
+      assert {:ok, %{}} = Presence.init([])
+    end
+  end
+
+  describe "handle_metas/4" do
+    setup do
+      # Subscribe to test topic to receive broadcasts
+      topic = "test:topic:#{:erlang.unique_integer([:positive])}"
+      Phoenix.PubSub.subscribe(Blog.PubSub, topic)
+
+      {:ok, topic: topic}
+    end
+
+    test "broadcasts viewer count on joins", %{topic: topic} do
+      joins = %{"user1" => %{metas: [%{phx_ref: "ref1"}]}}
+      leaves = %{}
+      presences = %{"user1" => %{metas: [%{phx_ref: "ref1"}]}}
+      state = %{}
+
+      assert {:ok, ^state} = Presence.handle_metas(topic, %{joins: joins, leaves: leaves}, presences, state)
+
+      assert_receive {:viewer_count_updated, ^topic, 1}
+      assert_receive {:viewer_joined, ^topic}
+    end
+
+    test "broadcasts viewer count on leaves", %{topic: topic} do
+      joins = %{}
+      leaves = %{"user1" => %{metas: [%{phx_ref: "ref1"}]}}
+      presences = %{}
+      state = %{}
+
+      assert {:ok, ^state} = Presence.handle_metas(topic, %{joins: joins, leaves: leaves}, presences, state)
+
+      assert_receive {:viewer_count_updated, ^topic, 0}
+      assert_receive {:viewer_left, ^topic}
+    end
+
+    test "broadcasts correct count with multiple users", %{topic: topic} do
+      joins = %{
+        "user2" => %{metas: [%{phx_ref: "ref2"}]}
+      }
+
+      leaves = %{}
+
+      presences = %{
+        "user1" => %{metas: [%{phx_ref: "ref1"}]},
+        "user2" => %{metas: [%{phx_ref: "ref2"}]}
+      }
+
+      state = %{}
+
+      assert {:ok, ^state} = Presence.handle_metas(topic, %{joins: joins, leaves: leaves}, presences, state)
+
+      assert_receive {:viewer_count_updated, ^topic, 2}
+    end
+
+    test "broadcasts multiple join events for multiple users", %{topic: topic} do
+      joins = %{
+        "user1" => %{metas: [%{phx_ref: "ref1"}]},
+        "user2" => %{metas: [%{phx_ref: "ref2"}]}
+      }
+
+      leaves = %{}
+
+      presences = %{
+        "user1" => %{metas: [%{phx_ref: "ref1"}]},
+        "user2" => %{metas: [%{phx_ref: "ref2"}]}
+      }
+
+      state = %{}
+
+      assert {:ok, ^state} = Presence.handle_metas(topic, %{joins: joins, leaves: leaves}, presences, state)
+
+      assert_receive {:viewer_joined, ^topic}
+      assert_receive {:viewer_joined, ^topic}
+    end
+
+    test "broadcasts both joins and leaves", %{topic: topic} do
+      joins = %{"user2" => %{metas: [%{phx_ref: "ref2"}]}}
+      leaves = %{"user1" => %{metas: [%{phx_ref: "ref1"}]}}
+      presences = %{"user2" => %{metas: [%{phx_ref: "ref2"}]}}
+      state = %{}
+
+      assert {:ok, ^state} = Presence.handle_metas(topic, %{joins: joins, leaves: leaves}, presences, state)
+
+      assert_receive {:viewer_count_updated, ^topic, 1}
+      assert_receive {:viewer_joined, ^topic}
+      assert_receive {:viewer_left, ^topic}
+    end
+  end
+end

--- a/apps/blog_web/test/blog_web/viewers_test.exs
+++ b/apps/blog_web/test/blog_web/viewers_test.exs
@@ -1,0 +1,155 @@
+defmodule BlogWeb.ViewersTest do
+  use BlogWeb.ConnCase, async: true
+
+  alias BlogWeb.Viewers
+
+  setup do
+    # Generate unique topics for each test to avoid conflicts
+    base_topic = "test:viewers:#{:erlang.unique_integer([:positive])}"
+
+    {:ok, topic: base_topic}
+  end
+
+  describe "track_viewer/4" do
+    test "tracks a viewer on a topic", %{topic: topic} do
+      key = "user123"
+
+      assert {:ok, _ref} = Viewers.track_viewer(self(), topic, key)
+
+      # Verify the viewer is tracked
+      assert Viewers.get_viewer_count(topic) == 1
+    end
+
+    test "tracks multiple viewers on the same topic", %{topic: topic} do
+      assert {:ok, _} = Viewers.track_viewer(self(), topic, "user1")
+      assert {:ok, _} = Viewers.track_viewer(self(), topic, "user2")
+
+      assert Viewers.get_viewer_count(topic) == 2
+    end
+
+    test "accepts metadata", %{topic: topic} do
+      meta = %{joined_at: System.system_time()}
+
+      assert {:ok, _ref} = Viewers.track_viewer(self(), topic, "user1", meta)
+      assert Viewers.get_viewer_count(topic) == 1
+    end
+  end
+
+  describe "untrack_viewer/3" do
+    test "untracks a viewer from a topic", %{topic: topic} do
+      key = "user123"
+
+      {:ok, _} = Viewers.track_viewer(self(), topic, key)
+      assert Viewers.get_viewer_count(topic) == 1
+
+      :ok = Viewers.untrack_viewer(self(), topic, key)
+
+      # Use sys.get_state to ensure presence has processed the untrack
+      _ = :sys.get_state(BlogWeb.Presence)
+
+      assert Viewers.get_viewer_count(topic) == 0
+    end
+
+    test "only untracks the specified viewer", %{topic: topic} do
+      {:ok, _} = Viewers.track_viewer(self(), topic, "user1")
+      {:ok, _} = Viewers.track_viewer(self(), topic, "user2")
+
+      :ok = Viewers.untrack_viewer(self(), topic, "user1")
+      _ = :sys.get_state(BlogWeb.Presence)
+
+      assert Viewers.get_viewer_count(topic) == 1
+    end
+  end
+
+  describe "get_viewer_count/1" do
+    test "returns 0 for empty topic", %{topic: topic} do
+      assert Viewers.get_viewer_count(topic) == 0
+    end
+
+    test "returns correct count for topic with viewers", %{topic: topic} do
+      {:ok, _} = Viewers.track_viewer(self(), topic, "user1")
+      {:ok, _} = Viewers.track_viewer(self(), topic, "user2")
+      {:ok, _} = Viewers.track_viewer(self(), topic, "user3")
+
+      assert Viewers.get_viewer_count(topic) == 3
+    end
+  end
+
+  describe "get_all_counts/0" do
+    test "returns map with all topic counts" do
+      counts = Viewers.get_all_counts()
+
+      assert is_map(counts)
+      assert Map.has_key?(counts, :site)
+      assert Map.has_key?(counts, :home)
+      assert Map.has_key?(counts, :posts)
+      assert Map.has_key?(counts, :projects)
+      assert Map.has_key?(counts, :gallery)
+
+      assert is_integer(counts.site)
+      assert is_integer(counts.home)
+      assert is_integer(counts.posts)
+      assert is_integer(counts.projects)
+      assert is_integer(counts.gallery)
+    end
+  end
+
+  describe "subscribe/1" do
+    test "subscribes to topic updates", %{topic: topic} do
+      assert :ok = Viewers.subscribe(topic)
+
+      # Track a viewer to trigger a broadcast
+      {:ok, _} = Viewers.track_viewer(self(), topic, "user1")
+
+      # Should receive presence update messages
+      assert_receive {:viewer_count_updated, ^topic, 1}, 500
+      assert_receive {:viewer_joined, ^topic}, 500
+    end
+
+    test "receives leave events", %{topic: topic} do
+      assert :ok = Viewers.subscribe(topic)
+
+      {:ok, _} = Viewers.track_viewer(self(), topic, "user1")
+      assert_receive {:viewer_count_updated, ^topic, 1}, 500
+
+      :ok = Viewers.untrack_viewer(self(), topic, "user1")
+      assert_receive {:viewer_count_updated, ^topic, 0}, 500
+      assert_receive {:viewer_left, ^topic}, 500
+    end
+  end
+
+  describe "site_topic/0" do
+    test "returns site-wide topic string" do
+      assert Viewers.site_topic() == "viewers:site"
+    end
+  end
+
+  describe "page_topic/1" do
+    test "returns correct topic for home page" do
+      assert Viewers.page_topic(:home) == "viewers:page:home"
+    end
+
+    test "returns correct topic for posts page" do
+      assert Viewers.page_topic(:posts) == "viewers:page:posts"
+    end
+
+    test "returns correct topic for projects page" do
+      assert Viewers.page_topic(:projects) == "viewers:page:projects"
+    end
+
+    test "returns correct topic for gallery page" do
+      assert Viewers.page_topic(:gallery) == "viewers:page:gallery"
+    end
+  end
+
+  describe "post_topic/1" do
+    test "returns topic for specific post by slug" do
+      assert Viewers.post_topic("hello-world") == "viewers:page:post:hello-world"
+    end
+
+    test "handles different slug formats" do
+      assert Viewers.post_topic("my-awesome-post") == "viewers:page:post:my-awesome-post"
+      assert Viewers.post_topic("2024-01-15-post") == "viewers:page:post:2024-01-15-post"
+    end
+  end
+end


### PR DESCRIPTION
Implements real-time viewer tracking using Phoenix.Presence
Displays site-wide and page-specific viewer counts in aside sections across all LiveViews
Adds Viewers component with live PubSub updates

Closes #21